### PR TITLE
jQuery doesn't work on node 0.10.x

### DIFF
--- a/lib/Response.js
+++ b/lib/Response.js
@@ -3,7 +3,7 @@
 var url = require('url'),
     queryString = require('querystring'),
     _ = require('underscore'),
-    $ = require('jquery');
+    $ = require('jquery-loader').create();
 
 /**
  * Constructor to the Response object

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "q": "~0.9.3",
         "underscore": "~1.4.4",
-        "jquery": "~1.8.3"
+        "jquery-loader": "~1.2.0"
     },
     "devDependencies": {
         "mocha": "~1.9.0",


### PR DESCRIPTION
I've included a workaround for coolaj86/node-jquery#52 -- use `jquery-loader` instead of the package maintained by @coolaj86 (`node-jquery`). See more here: coolaj86/node-jquery#59
`jquery-loader` serves jQuery 1.10.1 by default which should not have an impact on how it is used in this project.
