### PR TITLE
Custom cache validation.

### DIFF
--- a/lib/requestify.js
+++ b/lib/requestify.js
@@ -133,13 +133,13 @@ var Requestify = (function() {
         return defer.promise;
     }
 
-
     /**
      * Request router, handles caching
      * @param {Request} request
+     * @param {cacheCheckFn} valid
      * @returns {Q.promise}
      */
-    function callRouter(request) {
+    function callRouter(request, valid) {
         var defer = Q.defer();
 
         if (!cache.isTransportAvailable() || request.method !== 'GET' || request.cache.cache === false) {
@@ -151,11 +151,10 @@ var Requestify = (function() {
          */
         cache.get(request.getFullUrl())
             .then(function(data) {
-                if (!data || (data.created + request.cache.expires > new Date().getTime())) {
+                if (!data || !valid(data, request)) {
                     call(request, defer);
                     return;
                 }
-
                 defer.resolve(new Response(data.code, data.headers, data.body));
             })
             .fail(function() {
@@ -172,13 +171,28 @@ var Requestify = (function() {
      */
     api = {
         /**
+         * Cache check callback. Must return falsy value when cache is no longer valid.
+         * @callback cacheCheckFn
+         * @example
+         * function (data, request) {
+         *   return data.created + request.cache.expires > new Date().getTime();
+         * }
+         * @param {{code: int, header: header, body: (string|object), created: int}} data
+         * @param {Request} request
+         * @returns {*} return value will be converted to Boolean.
+         */
+        cacheCheck: function (data, request) {
+            return data.created + request.cache.expires > Date.now();
+        },
+
+        /**
          * Execute HTTP request based on the given method and body
          * @param {string} url - The URL to execute
          * @param {{ method: string, dataType: string, headers: object, body: object, cookies: object, auth: object }} options
          * @returns {Q.promise} - Returns a promise, once resolved || rejected, Response object is given
          */
         request: function(url, options) {
-            return callRouter(new Request(url, options));
+            return callRouter(new Request(url, options), this.cacheCheck);
         },
 
         /**


### PR DESCRIPTION
Ability to customise cache validation with requestify.cacheCheck. Default behaviour is not changed.
