### PR TITLE
timer should be cleared once the request completes

### DIFF
--- a/lib/requestify.js
+++ b/lib/requestify.js
@@ -125,6 +125,7 @@ var Requestify = (function() {
          * Reject on error and pass the given error object
          */
         httpRequest.on('error', function(error) {
+            clearTimeout(timeout);
             defer.reject(error);
         });
 

--- a/lib/requestify.js
+++ b/lib/requestify.js
@@ -94,7 +94,6 @@ var Requestify = (function() {
          * Handle request callback
          */
         httpRequest = http.request(options, function(res) {
-            clearTimeout(timeout);
             var response = new Response(res.statusCode, res.headers);
 
             res.setEncoding(responseEncoding);
@@ -103,6 +102,7 @@ var Requestify = (function() {
             });
 
             res.on('end', function() {
+                clearTimeout(timeout);
                 if (isSuccessful(response.code)) {
                     storeCache(request.getFullUrl(), response.getCode(), response.getHeaders(), response.body, request.cache);
                     defer.resolve(response);


### PR DESCRIPTION
The timer should be cleared on receiving 'end' event on the 'response' object and/or on receiving 'error' event on the 'request' object.