### PR TITLE
Allow basic auth password to be null

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -268,7 +268,9 @@ Request.prototype.getContentType = function() {
 Request.prototype.getAuthorization = function() {
     var auth = this.auth;
 
-    if (!auth.username || !auth.password) {
+    // Allow an empty or undefined password if the username is defined
+    // Return null only if both the username and password are empty
+    if (!auth.username && typeof auth.password === 'undefined') {
         return null;
     }
 


### PR DESCRIPTION
Providing basic auth credentials with an empty password causes the auth to be set to null, which is not correct. e.g.
```json
{
  "username": "kevin",
  "password": ""
}
```
Basic auth is now set to null only if both the username and password are not provided or empty