### PR TITLE
[MongoDB] Fix getting a cached response

### DIFF
--- a/lib/cache-transporters/mongo-transporter.js
+++ b/lib/cache-transporters/mongo-transporter.js
@@ -55,7 +55,12 @@ module.exports = function (mongooseInstance, cacheCollection) {
          * @param {Function} callback
          */
         get: function(url, callback) {
-            RequestifyResponse.findById(url, callback);
+            RequestifyResponse.findById(url, function (err, result) {
+                if (err) {
+                    return callback(err);
+                }
+                callback(null, result.response);
+            });
         },
 
         /**


### PR DESCRIPTION
The problem is that we are returning the entire mongo object instead of the response.