### PR TITLE
Added caching option to allow returning cached data before an update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,15 @@ If null will be given, the body will be served as string.
 #### `timeout {number} `
 Set a timeout (in milliseconds) for the request.
 
-#### `cache {{ cache: boolean, expires: number }}`
+#### `cache {{ cache: boolean, expires: number, cachedFirst: boolean }}`
 Requistify has built-in Redis based caching mechanism. For using this feature, set the cache property to true using the following object:
 
 ```javascript
 requestify.get('http://examples.com/api/foo', {
     cache: {
     	cache: true, // Will set caching to true for this request.
-    	expires: 3600 // Time for cache to expire in milliseconds
+    	expires: 3600, // Time for cache to expire in milliseconds
+    	cachedFirst: false // Will return cached data before updating cache
     }
 });
 ```

--- a/lib/requestify.js
+++ b/lib/requestify.js
@@ -158,6 +158,14 @@ var Requestify = (function() {
         cache.get(request.getFullUrl())
             .then(function(data) {
                 if (!data || (expirationTime(data) <= new Date().getTime())) {
+                    // cachedFirst indicates if we should return the cached data
+                    // before updating it
+                    if (request.cache.cachedFirst) {
+                        // return cached data
+                        defer.resolve(new Response(data.code, data.headers, data.body));
+                    }
+
+                    // make request and update cache
                     call(request, defer);
                     return;
                 }
@@ -180,7 +188,15 @@ var Requestify = (function() {
         /**
          * Execute HTTP request based on the given method and body
          * @param {string} url - The URL to execute
-         * @param {{ method: string, dataType: string, headers: object, body: object, cookies: object, auth: object }} options
+         * @param {{ 
+         *    method: string, 
+         *    dataType: string, 
+         *    headers: object, 
+         *    body: object, 
+         *    cookies: object, 
+         *    auth: object,
+         *    cache: object
+         * }} options
          * @returns {Q.promise} - Returns a promise, once resolved || rejected, Response object is given
          */
         request: function(url, options) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Simplifies node HTTP request making (HTTP client) with caching support.",
   "version": "0.2.3",
   "scripts": {
-    "test": "mocha -R spec test/**/*.js test/*.js"
+    "test": "mocha -R spec test/**/*.js test/*.js",
+    "test-watch": "mocha --watch -R spec test/**/*.js test/*.js"
   },
   "license": "MIT",
   "tags": [

--- a/test/requestify-spec.js
+++ b/test/requestify-spec.js
@@ -128,11 +128,6 @@ describe('Requestify', function() {
                     done(e);
                 }
             });
-
-            // expect(success.called).to.equal(true);
-            // console.log('---- success?', success.called);
-            // expect(requestify.request.called).to.equal(true);
-            // expect(requestify.request.returned(cachedDataStub)).to.equal(true);
         });
     });
 


### PR DESCRIPTION
This ensures faster responses when returning expired data is acceptable.
Expired data will be returned once, and then refreshed in the cache.
In some cases this is better than having to wait longer for up to date data.