### PR TITLE
Add withCredentials flag for global fetch

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -30,7 +30,8 @@ function Request(url, options) {
     this.cache = options.cache || { cache: false, expires: 3600 };
     this.timeout = options.timeout || 30000;
     this.cookies(options.cookies);
-    this.redirect = options.redirect || false
+    this.redirect = options.redirect || false;
+	this.withCredentials = options.withCredentials || false;
 }
 
 /**
@@ -281,5 +282,11 @@ Request.prototype.getAuthorization = function() {
 
     return auth.username + ':' + auth.password;
 };
-
+/**
+ * Returns the current withCredentials flag
+ * @returns {boolean}
+ */
+Request.prototype.getWithCredentials = function() {
+    return this.withCredentials;
+};
 module.exports = Request;

--- a/lib/requestify.js
+++ b/lib/requestify.js
@@ -90,7 +90,8 @@ var Requestify = (function() {
             method: request.method,
             auth: request.getAuthorization(),
             headers: request.getHeaders(),
-            redirect : request.getRedirect()
+            redirect : request.getRedirect(),
+			withCredentials: request.getWithCredentials()
         };
 
         /**


### PR DESCRIPTION
Supporting CORS, fixing issue when using session id not on the same
domain, on the global fetch there is withCredentials flag, if its true
it will set the credentials to "include" otherwise to same-origin.